### PR TITLE
Update renovate config file

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,20 @@
 {
   "extends": [
-    // Base config - https://github.com/giantswarm/renovate-presets/blob/main/default.json5
     "github>giantswarm/renovate-presets:default.json5",
+    "github>giantswarm/renovate-presets:lang-go.json5",
+    "github>giantswarm/renovate-presets:disable-vendir.json5"
   ],
+  "packageRules": [
+    {
+      "description": "Automerge architect updates",
+      "matchFileNames": [
+        ".circleci/config.yml"
+      ],
+      "matchDepNames": [
+        "architect"
+      ],
+      "groupName": "Architect",
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Updates renovate config file disabling vendir and allowing renovate to automerge Architect updates.