### PR TITLE
Update CRDs definitions with extra columns

### DIFF
--- a/api/v1alpha1/automatedexception_types.go
+++ b/api/v1alpha1/automatedexception_types.go
@@ -26,9 +26,13 @@ type AutomatedExceptionStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-//+kubebuilder:resource:shortName=autopolex
+// +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=autopolex
+// +kubebuilder:printcolumn:name="Namespaces",type=string,JSONPath=`.spec.targets[].namespaces`
+// +kubebuilder:printcolumn:name="Kind",type=string,JSONPath=`.spec.targets[].kind`
+// +kubebuilder:printcolumn:name="Names",type=string,JSONPath=`.spec.targets[].names`
+// +kubebuilder:printcolumn:name="Policies",type=string,JSONPath=`.spec.policies`
 
 // AutomatedException is the Schema for the automatedexceptions API
 type AutomatedException struct {

--- a/api/v1alpha1/policy_types.go
+++ b/api/v1alpha1/policy_types.go
@@ -34,6 +34,7 @@ type PolicyStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=gspol;gspolicy,scope=Cluster
+// +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.defaultPolicyState`
 // Policy is the Schema for the Policies API
 // +k8s:openapi-gen=true
 type Policy struct {

--- a/api/v1alpha1/policymanifest_types.go
+++ b/api/v1alpha1/policymanifest_types.go
@@ -31,6 +31,7 @@ type PolicyManifestSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=polman,scope=Cluster
+// +kubebuilder:printcolumn:name="Mode",type=string,JSONPath=`.spec.mode`
 // PolicyManifest is the Schema for the policymanifests API
 // +k8s:openapi-gen=true
 type PolicyManifest struct {

--- a/crds/policy.giantswarm.io_automatedexceptions.yaml
+++ b/crds/policy.giantswarm.io_automatedexceptions.yaml
@@ -16,7 +16,20 @@ spec:
     singular: automatedexception
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.targets[].namespaces
+      name: Namespaces
+      type: string
+    - jsonPath: .spec.targets[].kind
+      name: Kind
+      type: string
+    - jsonPath: .spec.targets[].names
+      name: Names
+      type: string
+    - jsonPath: .spec.policies
+      name: Policies
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: AutomatedException is the Schema for the automatedexceptions

--- a/crds/policy.giantswarm.io_policies.yaml
+++ b/crds/policy.giantswarm.io_policies.yaml
@@ -17,7 +17,11 @@ spec:
     singular: policy
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.defaultPolicyState
+      name: Mode
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Policy is the Schema for the Policies API
@@ -56,3 +60,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/crds/policy.giantswarm.io_policymanifests.yaml
+++ b/crds/policy.giantswarm.io_policymanifests.yaml
@@ -16,7 +16,11 @@ spec:
     singular: policymanifest
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.mode
+      name: Mode
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: PolicyManifest is the Schema for the policymanifests API
@@ -99,3 +103,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}


### PR DESCRIPTION
Enhances the CRDs visibility with custom columns

```
❯ kg gspolicy
NAME                             MODE
disallow-capabilities            enforce
disallow-capabilities-strict     enforce
disallow-host-namespaces         enforce
disallow-host-path               enforce
disallow-host-ports              enforce
disallow-host-process            enforce
disallow-privilege-escalation    enforce
disallow-privileged-containers   enforce
disallow-proc-mount              enforce
disallow-selinux                 enforce
require-run-as-non-root-user     enforce
require-run-as-nonroot           warming
restrict-apparmor-profiles       enforce
restrict-seccomp                 warming
restrict-seccomp-strict          warming
restrict-sysctls                 enforce
restrict-volume-types            enforce
❯ kg polman
NAME                             MODE
disallow-capabilities            enforce
disallow-capabilities-strict     enforce
disallow-host-namespaces         enforce
disallow-host-path               enforce
disallow-host-ports              enforce
disallow-host-process            enforce
disallow-privilege-escalation    enforce
disallow-privileged-containers   enforce
disallow-proc-mount              enforce
disallow-selinux                 enforce
require-run-as-non-root-user     enforce
require-run-as-nonroot           warming
restrict-apparmor-profiles       enforce
restrict-seccomp                 warming
restrict-seccomp-strict          warming
restrict-sysctls                 enforce
restrict-volume-types            enforce
❯ kg automatedexceptions
NAME                                   NAMESPACES        KIND         NAMES                             POLICIES
64d67846-340a-47a6-a6a6-81af7462716a   ["kube-system"]   DaemonSet    ["alloy-logs"]                    ["require-run-as-nonroot"]
74d5ed9d-29e3-445b-8fe7-ef823d7921cb   ["kube-system"]   Deployment   ["etcd-k8s-res-count-exporter"]   ["require-run-as-nonroot"]
a4496fe6-26cc-4d3c-8f60-15a7f3037999   ["kube-system"]   DaemonSet    ["k8s-audit-metrics"]             ["require-run-as-nonroot"]
c2fe2ddd-be82-408e-904b-c93d815b2cee   ["kube-system"]   DaemonSet    ["k8s-dns-node-cache"]            ["require-run-as-nonroot","restrict-seccomp","restrict-seccomp-strict"]
ca66604e-6831-4768-837e-27c5448be990   ["kube-system"]   DaemonSet    ["capi-node-labeler"]             ["require-run-as-nonroot","restrict-seccomp-strict"]
```